### PR TITLE
Use crypton and bootstrap CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+# Trigger the workflow on push or pull request, but only for the main branch
+on:
+  pull_request:
+  push:
+    branches: ["master"]
+
+jobs:
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    outputs: 
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.6.0
+        with:
+          cabal-file: wreq.cabal
+          ubuntu: true
+          version: 0.1.6.0
+  tests:
+    name: ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout base repo
+        uses: actions/checkout@v4
+      - name: Set up Haskell
+        id: setup-haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: 'latest'
+      - name: Configure
+        run: cabal configure --enable-tests
+      - name: Freeze
+        run: cabal freeze
+      - name: Cache
+        uses: actions/cache@v3.3.3
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ runner.os }}-ghc-${{ matrix.ghc }}-
+      - name: Build
+        run: cabal new-build
+      - name: Test
+        run: cabal new-test all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Freeze
         run: cabal freeze
       - name: Cache
-        uses: actions/cache@v3.3.3
+        uses: actions/cache@v4.0.1
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
           key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-cabal-${{ hashFiles('**/plan.json') }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist-newstyle
+cabal.project.local

--- a/wreq.cabal
+++ b/wreq.cabal
@@ -37,7 +37,7 @@ maintainer:          bos@serpentine.com
 copyright:           2014 Bryan O'Sullivan
 category:            Web
 build-type:          Custom
-tested-with:         GHC==9.2.8
+tested-with:         GHC ==9.2.8 || ==9.4.8 || ==9.6.4
 extra-source-files:
   README.md
   TODO.md

--- a/wreq.cabal
+++ b/wreq.cabal
@@ -110,7 +110,7 @@ library
     bytestring >= 0.9,
     case-insensitive,
     containers,
-    cryptonite,
+    crypton,
     exceptions >= 0.5,
     ghc-prim,
     hashable,


### PR DESCRIPTION
This PR replaces cryptonite with crypton, as the former is deprecated. The PR uses https://github.com/Kleidukos/get-tested/ to generate a GitHub Actions test matrix from the GHC versions in the `tested-with` field of the cabal file.

Moreover a dependabot configuration is created to scan for updates to the actions. This will create the occasional PR to update the actions that we use (both from Github and third-party).